### PR TITLE
Add BSD support (and fix building on Linux)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = "1.0"
 
 [build-dependencies]
 gcc = "0.3"
+pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 extern crate gcc;
+extern crate pkg_config;
 
 use std::env;
 
@@ -14,6 +15,11 @@ fn main() {
 	if target.contains("windows") {
 		build.define("WEBVIEW_WINAPI", None);
 	} else if target.contains("linux") || target.contains("bsd") {
+		let webkit = pkg_config::Config::new().atleast_version("2.16").probe("webkit2gtk-4.0").unwrap();
+
+		for path in webkit.include_paths {
+			build.include(path);
+		}
 		build.define("WEBVIEW_GTK", None);
 	} else if target.contains("apple") {
 		build.define("WEBVIEW_COCOA", None);

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
 	let target = env::var("TARGET").unwrap();
 	if target.contains("windows") {
 		build.define("WEBVIEW_WINAPI", None);
-	} else if target.contains("linux") {
+	} else if target.contains("linux") || target.contains("bsd") {
 		build.define("WEBVIEW_GTK", None);
 	} else if target.contains("apple") {
 		build.define("WEBVIEW_COCOA", None);

--- a/webview-c/lib.c
+++ b/webview-c/lib.c
@@ -1,6 +1,7 @@
 #define WEBVIEW_IMPLEMENTATION
 #include "webview.h"
 
+extern "C" {
 void wrapper_webview_free(struct webview* w) {
 	free(w);
 }
@@ -24,4 +25,5 @@ struct webview* wrapper_webview_new(const char* title, const char* url, int widt
 
 void* wrapper_webview_get_userdata(struct webview* w) {
 	return w->userdata;
+}
 }


### PR DESCRIPTION
This makes the build script handle BSDs. I still can't compile on FreeBSD as I'm getting the same issue finding the header file that [/u/LousyBegger reported on Reddit](https://www.reddit.com/r/rust/comments/7rwf5k/start_rust2018_by_making_your_first_rust_desktop/dt07xtz/) but this gets it a little closer.